### PR TITLE
Add OpenAI backend and API hooks

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// TODO: 실제 OpenAI API 키를 입력하세요.
+const OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY';
+
+async function callOpenAI(prompt) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error('OpenAI API request failed');
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content || '';
+}
+
+app.post('/api/resume/analyze', async (req, res) => {
+  const { text } = req.body;
+
+  const prompt = `
+  // 여기에 자기소개서 분석을 위한 프롬프트를 작성하세요.
+  ${text}
+  `; // TODO: 프롬프트 내용을 원하는 대로 수정하세요.
+
+  try {
+    const result = await callOpenAI(prompt);
+    res.json({ result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to get response from OpenAI' });
+  }
+});
+
+app.post('/api/resume/generate', async (req, res) => {
+  const { keywords } = req.body;
+
+  const prompt = `
+  // 여기에 자기소개서 생성을 위한 프롬프트를 작성하세요.
+  ${keywords}
+  `; // TODO: 프롬프트 내용을 원하는 대로 수정하세요.
+
+  try {
+    const result = await callOpenAI(prompt);
+    res.json({ result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to get response from OpenAI' });
+  }
+});
+
+app.post('/api/interview/feedback', async (req, res) => {
+  const { question, answer } = req.body;
+
+  const prompt = `
+  // 여기에 면접 답변 평가 프롬프트를 작성하세요.
+  질문: ${question}
+  답변: ${answer}
+  `; // TODO: 프롬프트 내용을 원하는 대로 수정하세요.
+
+  try {
+    const result = await callOpenAI(prompt);
+    res.json({ result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to get response from OpenAI' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
+import { analyzeResume, generateResume } from "@/lib/api";
 import { 
   FileText, 
   Wand2, 
@@ -48,14 +49,21 @@ const ResumeManager = () => {
     }
 
     setIsAnalyzing(true);
-    // Simulate AI analysis
-    setTimeout(() => {
-      setIsAnalyzing(false);
+    try {
+      await analyzeResume(originalText);
       toast({
         title: "분석 완료",
         description: "AI 첨삭이 완료되었습니다. 결과를 확인해보세요.",
       });
-    }, 3000);
+    } catch (err) {
+      toast({
+        title: "오류",
+        description: "분석 요청 중 문제가 발생했습니다.",
+        variant: "destructive"
+      });
+    } finally {
+      setIsAnalyzing(false);
+    }
   };
 
   const handleGenerate = async () => {
@@ -69,14 +77,21 @@ const ResumeManager = () => {
     }
 
     setIsAnalyzing(true);
-    // Simulate AI generation
-    setTimeout(() => {
-      setIsAnalyzing(false);
+    try {
+      await generateResume(keywords);
       toast({
         title: "생성 완료",
         description: "AI가 자기소개서를 생성했습니다.",
       });
-    }, 5000);
+    } catch (err) {
+      toast({
+        title: "오류",
+        description: "생성 요청 중 문제가 발생했습니다.",
+        variant: "destructive"
+      });
+    } finally {
+      setIsAnalyzing(false);
+    }
   };
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,29 @@
+export async function analyzeResume(text: string) {
+  const res = await fetch('http://localhost:3001/api/resume/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error('Failed to analyze resume');
+  return res.json();
+}
+
+export async function generateResume(keywords: string) {
+  const res = await fetch('http://localhost:3001/api/resume/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ keywords }),
+  });
+  if (!res.ok) throw new Error('Failed to generate resume');
+  return res.json();
+}
+
+export async function getInterviewFeedback(question: string, answer: string) {
+  const res = await fetch('http://localhost:3001/api/interview/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question, answer }),
+  });
+  if (!res.ok) throw new Error('Failed to get interview feedback');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add minimal Express server with placeholder prompts
- create client helpers for backend calls
- connect resume manager to backend API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842b62da6e88332802d15ab298db3aa